### PR TITLE
added: ['returning story id when creating a new story', 'can specify labels when creating a story']

### DIFF
--- a/pivotal_tools/cli.py
+++ b/pivotal_tools/cli.py
@@ -286,7 +286,11 @@ def create_story(project, arguments):
 
     stories = {'story': story}
 
-    project.create_story(stories)
+    newstory = project.create_story(stories)
+
+    # if a story was created successfully, let the user know the story ID
+    if newstory:
+        print newstory.story_id
 
 
 def update_status(arguments):

--- a/pivotal_tools/cli.py
+++ b/pivotal_tools/cli.py
@@ -48,7 +48,7 @@ Usage:
 Options:
   -h --help             Show this screen.
   --for=<user_name>     Username, or initials
-  --labels=<csv_list    Comma seperates list of labels to apply to the new story
+  --labels=<csv_list>   Comma seperates list of labels to apply to the new story
   --project-index=<pi>  If you have multiple projects, this is the index that the project shows up in my prompt
                         This is useful if you do not want to be prompted, and then you can pipe the output
 

--- a/pivotal_tools/cli.py
+++ b/pivotal_tools/cli.py
@@ -301,23 +301,23 @@ def update_status(arguments):
         story = load_story(story_id, arguments)
 
     if story is not None:
+        msg = lambda story, msg: "Story: [{}] {} is {}".format(story.story_id, story.name, msg)
         try:
-
             if arguments['start']:
                 story.start()
-                print "Story: [{}] {} is STARTED".format(story.story_id, story.name)
+                print msg(story, "STARTED")
             elif arguments['finish']:
                 story.finish()
-                print "Story: [{}] {} is FINISHED".format(story.story_id, story.name)
+                print msg(story, "FINISHED")
             elif arguments['deliver']:
                 story.deliver()
-                print "Story: [{}] {} is DELIVERED".format(story.story_id, story.name)
+                print msg(story, "DELIVERED")
             elif arguments['accept']:
                 story.accept()
-                print "Story: [{}] {} is ACCEPTED".format(story.story_id, story.name)
+                print msg(story, "ACCEPTED")
             elif arguments['reject']:
                 story.reject()
-                print "Story: [{}] {} is REJECTED".format(story.story_id, story.name)
+                print msg(story, "REJECTED")
 
         except InvalidStateException, e:
             print e.message

--- a/pivotal_tools/cli.py
+++ b/pivotal_tools/cli.py
@@ -36,7 +36,7 @@ Create a story
 
 
 Usage:
-  pivotal_tools create (feature|bug|chore) <title> [<description>] [--project-index=<pi>]
+  pivotal_tools create (feature|bug|chore) <title> [<description>] [--labels=<csv_list>] [--project-index=<pi>]
   pivotal_tools (start|finish|deliver|accept|reject) story <story_id> [--project-index=<pi>]
   pivotal_tools show stories [--project-index=<pi>] [--for=<user_name>] [--number=<number_of_stories>]
   pivotal_tools show story <story_id> [--project-index=<pi>]
@@ -48,6 +48,7 @@ Usage:
 Options:
   -h --help             Show this screen.
   --for=<user_name>     Username, or initials
+  --labels=<csv_list    Comma seperates list of labels to apply to the new story
   --project-index=<pi>  If you have multiple projects, this is the index that the project shows up in my prompt
                         This is useful if you do not want to be prompted, and then you can pipe the output
 
@@ -276,6 +277,8 @@ def create_story(project, arguments):
     story['name'] = arguments['<title>']
     if '<description>' in arguments:
         story['description'] = arguments['<description>']
+    if '--labels' in arguments:
+        story['labels'] = arguments['--labels']
 
     if arguments['bug']:
         story['story_type'] = 'bug'

--- a/pivotal_tools/pivotal.py
+++ b/pivotal_tools/pivotal.py
@@ -237,7 +237,14 @@ class Project(object):
     def create_story(self,story_dict):
         stories_url = "https://www.pivotaltracker.com/services/v3/projects/{}/stories".format(self.project_id)
         story_xml = dicttoxml.dicttoxml(story_dict, root=False)
-        _perform_pivotal_post(stories_url, story_xml)
+        response = _perform_pivotal_post(stories_url, story_xml)
+
+        # if story created successfully, return the resulting new story
+        if (response.status_code == 200):
+            root = ET.fromstring(response.text)
+            return Story.from_node(root)
+
+
 
     def unestimated_stories(self):
         stories = self.get_stories('type:feature state:unstarted')


### PR DESCRIPTION
It's helpful to see what the story ID is that was newly created to be able to do other things with it, like open it next.
